### PR TITLE
修复flyctl升级造成应用不能创建

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -14,12 +14,12 @@ if [ -z "${APP_NAME}" ]; then
 fi
 
 flyctl info --app "${APP_NAME}" >/tmp/${APP_NAME} 2>&1;
-if [ "$(cat /tmp/${APP_NAME} | grep -o "Could not resolve App")" = "Could not resolve App" ]; then
+if [ "$(cat /tmp/${APP_NAME} | grep -o "Could not resolve")" = "Could not resolve" ]; then
     printf '\e[33mCould not resolve app. Next, create the App.\n\e[0m'
     flyctl apps create "${APP_NAME}" >/dev/null 2>&1;
 
     flyctl info --app "${APP_NAME}" >/tmp/${APP_NAME} 2>&1;
-    if [ "$(cat /tmp/${APP_NAME} | grep -o "Could not resolve App")" != "Could not resolve App" ]; then
+    if [ "$(cat /tmp/${APP_NAME} | grep -o "Could not resolve")" != "Could not resolve" ]; then
         printf '\e[32mCreate app success.\n\e[0m'
     else
         printf '\e[31mCreate app failed.\n\e[0m' && exit 1


### PR DESCRIPTION
flyctl info命令旧版本在应用不存在时会返回【Error Could not resolve App】，新版返回结构为【Error Could not resolve】，最终造成不匹配不能创建新应用